### PR TITLE
Support for test reports with tear down errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 testpaths = "test"
 
 [tool.black]
-line-length = 99
+line-length = 90

--- a/test/test_pytest_update_test_results.py
+++ b/test/test_pytest_update_test_results.py
@@ -178,3 +178,25 @@ def test_duplicated_test_names(datadir: Path) -> None:
     testsuite_el = root_el.find("testsuite")
     assert testsuite_el.attrib["failures"] == "0"
     assert len(list(testsuite_el.iter("failure"))) == 0
+
+def test_error_on_teardown(datadir: Path) -> None:
+    retest_results = {
+        "test_error_on_teardown": TestReport(
+            nodeid="test/test_pytest_update_test_results.py::test_error_on_tear_down",
+            outcome="passed",
+            location=("test/test_pytest_update_test_results.py", 8, "test_error_on_tear_down"),
+            keywords={},
+            longrepr=None,
+            when="call",
+        )
+    }
+
+    original_junit_xml = datadir / "error_on_teardown.xml"
+    modified_junit_xml = datadir / "error_on_teardown.retest.xml"
+    modify_xml(original_junit_xml, retest_results, modified_junit_xml)    
+
+    et = ET.parse(modified_junit_xml)
+    root_el = et.getroot()
+    testsuite_el = root_el.find("testsuite")
+    assert testsuite_el.attrib["errors"] == "0"
+    assert testsuite_el.attrib["failures"] == "0"

--- a/test/test_pytest_update_test_results/error_on_teardown.xml
+++ b/test/test_pytest_update_test_results/error_on_teardown.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuites>
+  <testsuite errors="1" failures="1" hostname="BRWS009" name="pytest" skipped="0" tests="2" time="0.035" timestamp="2023-18-09T19:44:18.458004">
+  <testcase classname="test.test_flaky" name="test_passed" time="0.000" />
+  <testcase classname="test.test_pytest_update_test_results" name="test_error_on_tear_down" time="0.000">
+    <failure message="ZeroDivisionError: division by zero">tear_down_error = None def test_big_error_outcome(tear_down_error): print("HEllo") > 1 /0 E ZeroDivisionError: division by zero test\test_pytest_update_test_results.py:212: ZeroDivisionError</failure>
+  </testcase>
+  <testcase classname="test.test_pytest_update_test_results" name="test_error_on_tear_down" time="0.000">
+    <error message="failed on teardown with &quot;RuntimeError: fake&quot;">@pytest.fixture def tear_down_error(): yield > raise RuntimeError("fake") E RuntimeError: fake test\test_pytest_update_test_results.py:207: RuntimeError</error>
+  </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
Add test to cover cases where the test fails and an error occurs on the test tear down (usually within the tear down of a fixture).